### PR TITLE
adjust meta.profile according to MHD_047

### DIFF
--- a/StructureDefinition/structuredefinition-IHE_MHD_ProvideDocumentBundle_Comprehensive.xml
+++ b/StructureDefinition/structuredefinition-IHE_MHD_ProvideDocumentBundle_Comprehensive.xml
@@ -33,7 +33,7 @@
 	<description value="Profile on Transaction Bundle based on IHE IT Infrastructure Technical Framework Supplement - Mobile access to Health Documents (MHD) Rev. 3.1.  See http://wiki.ihe.net/index.php/Mobile_access_to_Health_Documents_(MHD)   The IHE MHD Profile text is Normative, this conformance resource is Informative." />
 
 	<copyright value="IHE http://www.ihe.net/Governance/#Intellectual_Property" />
-	<fhirVersion value="4.0.0" />
+	<fhirVersion value="4.0.1" />
 	<kind value="resource" />
 	<abstract value="false" />
 	<type value="Bundle" />
@@ -42,11 +42,20 @@
 	<differential>
 		<element id="Bundle.meta.profile">
 			<path value="Bundle.meta.profile" />
-			<short value="ITI-65" />
-			<definition value="IHE MHD Provide Document Bundle transaction" />
-			<min value="1" />
-			<max value="1" />
-			<fixedUri value="http://ihe.net/fhir/tag/iti-65" />
+			<slicing>
+				<discriminator>
+					<type value="value" />
+					<path value="$this" />
+				</discriminator>
+				<rules value="open"/>
+			</slicing>
+		</element>
+		<element id="Bundle.meta.profile:iti-65">
+			<path value="Bundle.meta.profile"/>
+			<sliceName value="iti-65"/>
+			<min value="1"/>
+			<max value="1"/>
+			<fixedCanonical value="http://ihe.net/fhir/StructureDefinition/IHE_MHD_Provide_Comprehensive_DocumentBundle" />
 		</element>
 		<element id="Bundle.type">
 			<path value="Bundle.type" />

--- a/StructureDefinition/structuredefinition-IHE_MHD_ProvideDocumentBundle_Minimal.xml
+++ b/StructureDefinition/structuredefinition-IHE_MHD_ProvideDocumentBundle_Minimal.xml
@@ -33,7 +33,7 @@
 	<description value="Profile on Transaction Bundle based on IHE IT Infrastructure Technical Framework Supplement - Mobile access to Health Documents (MHD) Rev. 3.1.  See http://wiki.ihe.net/index.php/Mobile_access_to_Health_Documents_(MHD)   The IHE MHD Profile text is Normative, this conformance resource is Informative." />
 
 	<copyright value="IHE http://www.ihe.net/Governance/#Intellectual_Property" />
-	<fhirVersion value="4.0.0" />
+	<fhirVersion value="4.0.1" />
 	<kind value="resource" />
 	<abstract value="false" />
 	<type value="Bundle" />
@@ -42,11 +42,20 @@
 	<differential>
 		<element id="Bundle.meta.profile">
 			<path value="Bundle.meta.profile" />
-			<short value="ITI-65" />
-			<definition value="IHE MHD Provide Document Bundle transaction" />
-			<min value="1" />
-			<max value="1" />
-			<fixedUri value="http://ihe.net/fhir/tag/iti-65" />
+			<slicing>
+				<discriminator>
+					<type value="value" />
+					<path value="$this" />
+				</discriminator>
+				<rules value="open"/>
+			</slicing>
+		</element>
+		<element id="Bundle.meta.profile:iti-65">
+			<path value="Bundle.meta.profile"/>
+			<sliceName value="iti-65"/>
+			<min value="1"/>
+			<max value="1"/>
+			<fixedCanonical value="http://ihe.net/fhir/StructureDefinition/IHE_MHD_Provide_Minimal_DocumentBundle" />
 		</element>
 		<element id="Bundle.type">
 			<path value="Bundle.type" />


### PR DESCRIPTION
Closed Issue MHD 47 says:

The tag used to indicate the Provide transaction must change. The encoding rules don't allow for "-" character. We could just change ITI-65 into ITI_65, but a breaking change is a breaking change. So, we have replaced with an actual structure definition based in the same URI space as our other Structure definitions. This means that we would no-longer use http://ihe.net/fhir/tag/iti-65, but rather we would use http://ihe.net/fhir/StructureDefinition/IHE_MHD_Provide_Comprehensive_DocumentBundle, or http://ihe.net/fhir/StructureDefinition/IHE_MHD_Provide_Minimal_DocumentBundle"

This PR removes the http://ihe.net/fhir/tag/iti-65 requirement and expects that one of the new canonical url's i used.