### PR TITLE
Changing type of resource for IHE_QEDm_Provenance

### DIFF
--- a/ImplementationGuide/implementationguide-IHE_QEDm.xml
+++ b/ImplementationGuide/implementationguide-IHE_QEDm.xml
@@ -47,7 +47,7 @@ The IHE QEDm Profile text is Normative, this conformance resource is Informative
 		</resource>
 		<resource>
 			<reference>
-			<reference value="http://ihe.net/fhir/CapabilityStatement/IHE_QEDm_Provenance" />
+			<reference value="http://ihe.net/fhir/StructureDefinition/IHE_QEDm_Provenance" />
 			</reference>
 		</resource>
 	</manifest>


### PR DESCRIPTION
Regarding this web page : https://wiki.ihe.net/index.php/Query_for_Existing_Data_for_Mobile_(QEDm) IHE_QEDm_Provenance should be a StructureDefinition not a CapibilityStatement